### PR TITLE
fix: height is not accurate when revealing

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -552,7 +552,6 @@
 			$saparator 			= $scope.find('.pp-content-reveal-saparator'),
 			$button				= $scope.find('.pp-content-reveal-button-inner'),
 			buttonWrapper       = $scope.find('.pp-content-reveal-buttons-wrapper'),
-			contentOuterHeight 	= $content.outerHeight(),
 			scrollTop           = contentWrapper.data('scroll-top'),
 			contentVisibility   = contentWrapper.data('visibility'),
 			contentHeightCustom = contentWrapper.data('content-height'),
@@ -647,7 +646,7 @@
 			$(this).toggleClass('pp-content-revealed');
 
 			if ( $button.hasClass('pp-content-revealed') ) {
-				contentWrapper.animate({ height: ( contentOuterHeight + 'px') }, speedUnreveal);
+				contentWrapper.animate({ height: ( $content.outerHeight() + 'px') }, speedUnreveal);
 			} else {
 				contentWrapper.animate({ height: ( contentWrapperHeight + 'px') }, speedUnreveal);
 


### PR DESCRIPTION
Sometimes reveal widgets can be hidden, for example it can be in the tabbed component which has some hidden tabs or you can say their CSS display is none, so if this reveal widget is on those tabs then it will be hidden and the height will not be accurate when the JS is initialize it will be 0. So rather then saving the original height into a variable we can find out it's real height on the fly.